### PR TITLE
Wrap debug middleware in DEBUG check

### DIFF
--- a/settings/components/debug.py
+++ b/settings/components/debug.py
@@ -7,10 +7,11 @@ if settings.DEBUG:
 
 # django-querycount
 # django-debug-toolbar
-settings.MIDDLEWARE += [
-    'querycount.middleware.QueryCountMiddleware',
-    'debug_toolbar.middleware.DebugToolbarMiddleware',
-]
+if settings.DEBUG:
+    settings.MIDDLEWARE += [
+        'querycount.middleware.QueryCountMiddleware',
+        'debug_toolbar.middleware.DebugToolbarMiddleware',
+    ]
 
 # django-debug-toolbar
 INTERNAL_IPS = [


### PR DESCRIPTION
## Summary
- Guard debug middleware additions behind `settings.DEBUG`

## Testing
- `ruff check settings/components/debug.py`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6895ba6aed0c833280d6916cf17cd147